### PR TITLE
Update Renovate configuration for scheduling and checks

### DIFF
--- a/.github/workflows/tools_renovate.yml
+++ b/.github/workflows/tools_renovate.yml
@@ -3,7 +3,7 @@ name: Tools - Renovate
 
 "on":
   schedule:
-    - cron: "0 6 * * *"  # jeden Tag um 06:00 Uhr
+    - cron: "0 5 * * 6"  # Jeden Samstag um 05:00 Uhr
   workflow_dispatch:
     inputs:
       logLevel:

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,9 @@
   prHourlyLimit: 0,
   prConcurrentLimit: 0,
   automerge: false,
+  minimumReleaseAge: '7 days',
+  minimumReleaseAgeBehaviour: 'timestamp-required',
+  internalChecksFilter: 'strict',  
   enabledManagers: [
     'github-actions',
     'dockerfile',


### PR DESCRIPTION
Adjust the Renovate configuration to run every Saturday at 05:00 and implement minimum release age and internal checks for better management of dependencies.